### PR TITLE
Offer option to disable cpu load check when not in production

### DIFF
--- a/src/CpuLoadCheck.php
+++ b/src/CpuLoadCheck.php
@@ -10,6 +10,7 @@ class CpuLoadCheck extends Check
     protected ?float $failWhenLoadIsHigherInTheLastMinute = null;
     protected ?float $failWhenLoadIsHigherInTheLast5Minutes = null;
     protected ?float $failWhenLoadIsHigherInTheLast15Minutes = null;
+    protected bool $onlyInProduction = false;
 
     public function failWhenLoadIsHigherInTheLastMinute(float $load): self
     {
@@ -31,9 +32,20 @@ class CpuLoadCheck extends Check
 
         return $this;
     }
+    
+    public function onlyInProduction(): self
+    {
+        $this->onlyInProduction = true;
+
+        return $this;
+    }
 
     public function run(): Result
     {
+        if($this->onlyInProduction && ! App()->environment('production') ) {
+            return Result::make()->warning()->shortSummary('Only runs in production');
+        }
+        
         $cpuLoad = $this->measureCpuLoad();
 
         $result = Result::make()

--- a/tests/CpuLoadCheckTest.php
+++ b/tests/CpuLoadCheckTest.php
@@ -54,3 +54,15 @@ it('will result in an failure when CPU load last 15 minutes is too high', functi
     [1.20, Status::ok()],
     [1.21, Status::failed()],
 ]);
+
+it('will not run in development with onlyInProduction enabled', function() {
+    //
+});
+
+it('will run in production regardless the onlyInProduction setting', function() {
+    //
+});
+
+it('will run in development with onlyInProduction disabled', function() {
+    //
+});


### PR DESCRIPTION
I noticed my health checks did get an error when I ran them in development. This made me think that often the development environment is a Windows or IOS where the cpu load function is indeed not available. 

This feature allows adding `CpuLoadCheck::new()->onlyInProduction()` when defining the health checks. This allows for local testing of all the health checks without the cpu load check causing an exception/error.

I added a test skeleton, but unfortunately am not confident enough in pest to write them myself. I didn't contribute to the documentation/readme.MD, as it is in another repository.