### PR TITLE
Add sys_getloadavg function existence check

### DIFF
--- a/src/CpuLoad.php
+++ b/src/CpuLoad.php
@@ -8,7 +8,11 @@ class CpuLoad
 {
     public static function measure(): self
     {
-        $result = sys_getloadavg();
+        $result = false;
+
+        if (function_exists('sys_getloadavg')) {
+            $result = sys_getloadavg();
+        }
 
         if (! $result) {
             throw CouldNotMeasureCpuLoad::make();


### PR DESCRIPTION
The [sys_getloadavg](https://www.php.net/manual/en/function.sys-getloadavg.php#refsect1-function.sys-getloadavg-notes) is not implemented on Windows platforms. When it is called, it throws `Fatal error: Call to undefined function sys_getloadavg()`. There are some workarounds on the Internet but it seems easier just to check if the function exists and provide no information on these platforms.