### PR TITLE
Round load values to 2 decimals

### DIFF
--- a/src/CpuLoad.php
+++ b/src/CpuLoad.php
@@ -17,6 +17,8 @@ class CpuLoad
         if (! $result) {
             throw CouldNotMeasureCpuLoad::make();
         }
+        
+        $result = array_map(fn ($n) => round($n, 2), $result);
 
         return new self(...$result);
     }


### PR DESCRIPTION
Records and display: `1.06 2.18 1.94`

Instead of: `1.056640625 2.177734375 1.93603515625`