### PR TITLE
Update some dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,24 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.0, 8.1, 8.2, 8.3]
-        laravel: [8.*]
+        laravel: [8.*, 9.*, 10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: ^6.23
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
+        exclude:
+          - php: 8.0
+            laravel: 10.*
+          - php: 8.0
+            laravel: 11.*
+          - php: 8.1
+            laravel: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3]
         laravel: [8.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5|^10.5",
         "spatie/laravel-health": "^1.2",
         "spatie/laravel-ray": "^1.26"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10",
-        "pestphp/pest": "^1.21",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "nunomaduro/collision": "^5.10|^6.1|^7.0|^8.0",
+        "pestphp/pest": "^1.21|^2.3",
+        "pestphp/pest-plugin-laravel": "^1.21|^2.3",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",


### PR DESCRIPTION
Hello again,

I'd like to propose to make this package more consistent with the main Laravel-Health package.

This PR adds support of PHP 8.3 and all of the supported Laravel versions to the github `run-tests` action.
In addition, this PR updates dependencies and adds:
- support for PHPUnit 10
- support for Pest 2
- support for different versions of Collision

Btw, it seems that the support of Laravel 8 might be dropped in all of the packages (Laravel-Health and checks). At least, it is not supported by the [Security-Advisories](https://github.com/spatie/security-advisories-health-check) package.
